### PR TITLE
feat: sync landing page with shipped product (integrations + presets)

### DIFF
--- a/public/icon/account-abstraction.svg
+++ b/public/icon/account-abstraction.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
+  <rect x="14" y="22" width="74" height="58" rx="13" fill="#E8F1FE" stroke="#0070ED" stroke-width="5"/>
+  <path d="M14 40 h74" stroke="#0070ED" stroke-width="5" stroke-linecap="round" opacity="0.35"/>
+  <circle cx="52" cy="84" r="15" fill="#4DA3FF" stroke="#FFFFFF" stroke-width="4"/>
+  <circle cx="82" cy="80" r="23" fill="#0070ED" stroke="#FFFFFF" stroke-width="5"/>
+  <path d="M85 66 l-12 16 h9 l-4 12 13-17 h-9 z" fill="#FFFFFF"/>
+</svg>

--- a/src/app/discover/account-abstraction/page.tsx
+++ b/src/app/discover/account-abstraction/page.tsx
@@ -1,0 +1,320 @@
+"use client";
+import { Box, Flex, Link, List, Text } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import backIcon from "@/assets/icon/back.svg";
+import Image from "next/image";
+import { SocialButton } from "@/components/ui/social-button";
+import { IntegrationLogo } from "@/components/ui/integration-logo";
+import { useState } from "react";
+
+const ERC_4337_SPEC_URL = "https://eips.ethereum.org/EIPS/eip-4337";
+
+const BackButton = () => {
+  const router = useRouter();
+  const [isHover, setIsHover] = useState(false);
+  return (
+    <Flex
+      gap={"12px"}
+      ml={"30px"}
+      alignItems={"center"}
+      cursor={"pointer"}
+      onClick={() => router.push("/discover?category=integration")}
+      zIndex={100}
+      onMouseEnter={() => setIsHover(true)}
+      onMouseLeave={() => setIsHover(false)}
+    >
+      <Image src={backIcon} alt="back" />
+      <Text
+        fontSize={"18px"}
+        fontWeight={700}
+        letterSpacing={"-0.54px"}
+        cursor={"pointer"}
+        textDecoration={isHover ? "underline" : "none"}
+      >
+        Back
+      </Text>
+    </Flex>
+  );
+};
+
+const RouteComponent = () => {
+  const router = useRouter();
+  return (
+    <Flex
+      gap={"12px"}
+      alignItems={"center"}
+      fontSize={"12px"}
+      lineHeight={"normal"}
+      cursor={"pointer"}
+    >
+      <Text
+        _hover={{ textDecoration: "underline" }}
+        onClick={() => router.push("/discover")}
+      >
+        Discover
+      </Text>
+      <Text opacity={0.25}>/</Text>
+      <Text
+        _hover={{ textDecoration: "underline" }}
+        onClick={() => router.push("/discover?category=integration")}
+      >
+        Integrations
+      </Text>
+      <Text opacity={0.25}>/</Text>
+      <Text color={"#0070ED"}>Account Abstraction</Text>
+    </Flex>
+  );
+};
+
+export default function AccountAbstractionPage() {
+  return (
+    <Box
+      pt={{ base: "108px", md: "138px", lg: "198px" }}
+      px={{ base: "15px", md: "31px", lg: "40px" }}
+      pb={"30px"}
+      w={"100%"}
+      minH={`calc(100vh - ${95}px)`}
+      bgColor={"#FAFBFC"}
+    >
+      <Flex flexDir={"column"} gap={"30px"} maxWidth={"1200px"} mx={"auto"}>
+        <Flex
+          position={"absolute"}
+          top={0}
+          left={0}
+          w={"100%"}
+          h={"100vh"}
+          zIndex={1}
+          bg={"url(/images/discover-bg.png) no-repeat center center"}
+          bgSize={"cover"}
+        ></Flex>
+        <BackButton />
+        <Flex
+          gap={"30px"}
+          flexDir={{ base: "column", lg: "row" }}
+          alignItems={"flex-start"}
+          zIndex={100}
+        >
+          <Flex
+            flexDir={"column"}
+            width={{ base: "100%", lg: "75%" }}
+            borderRadius={"15px"}
+            border={"1px solid #E1E8ED"}
+            bgColor={"#FFF"}
+            padding={{ base: "21px 21px 30px 21px", lg: "45px 30px 60px 30px" }}
+            gap={{ base: "60px", lg: "75px" }}
+            alignItems={"flex-start"}
+          >
+            <Flex flexDir={"column"} gap={"45px"}>
+              <RouteComponent />
+              <Flex flexDir={"column"} gap={"18px"}>
+                <Flex alignItems={"center"} gap={"15px"}>
+                  <IntegrationLogo
+                    name={"account-abstraction"}
+                    width={60}
+                    height={60}
+                  />
+                  <Flex
+                    gap={{ base: "6px", md: "12px" }}
+                    alignItems={{ base: "flex-start", md: "center" }}
+                    flexDir={{ base: "column", md: "row" }}
+                  >
+                    <Text
+                      fontSize={{ base: "21px", md: "36px" }}
+                      fontWeight={700}
+                      letterSpacing={"-1.08px"}
+                    >
+                      Account Abstraction
+                    </Text>
+                    <Text
+                      fontSize={{ base: "13px", md: "14px" }}
+                      fontWeight={400}
+                      lineHeight={"normal"}
+                    >
+                      Multi-Token Paymaster
+                    </Text>
+                  </Flex>
+                </Flex>
+                <Flex
+                  ml={{ base: "0px", md: "60px" }}
+                  flexDir={"column"}
+                  gap={"30px"}
+                >
+                  <Flex flexDir={"column"} gap={"30px"}>
+                    <Flex alignItems={"center"} gap={"45px"}>
+                      <Flex flexDir={"column"} gap={"3px"}>
+                        <Text fontSize={"12px"} fontWeight={400}>
+                          Created by
+                        </Text>
+                        <Text fontSize={"13px"} fontWeight={700}>
+                          Tokamak Rollup Hub Team
+                        </Text>
+                      </Flex>
+                      <Flex flexDir={"column"} gap={"3px"}>
+                        <Text fontSize={"12px"} fontWeight={400}>
+                          Available in
+                        </Text>
+                        <Text fontSize={"13px"} fontWeight={700}>
+                          Every preset
+                        </Text>
+                      </Flex>
+                    </Flex>
+                    <Flex gap={"12px"} flexWrap={"wrap"}>
+                      <SocialButton
+                        icon={"document"}
+                        label={"ERC-4337 Spec"}
+                        link={ERC_4337_SPEC_URL}
+                      />
+                    </Flex>
+                  </Flex>
+                </Flex>
+              </Flex>
+            </Flex>
+            <Flex flexDir={"column"} gap={"45px"}>
+              <Flex flexDir={"column"} gap={"6px"}>
+                <Text
+                  fontSize={"18px"}
+                  fontWeight={700}
+                  letterSpacing={"-0.54px"}
+                >
+                  Overview
+                </Text>
+                <Text fontSize={"15px"} fontWeight={400} lineHeight={"18px"}>
+                  Every rollup deployed with the Rollup Hub ships with ERC-4337
+                  Account Abstraction built in. An EntryPoint and a Multi-Token
+                  Paymaster are predeployed at genesis, so your users can pay
+                  transaction fees in tokens other than the native TON &mdash;
+                  no separate installation or preset required.
+                  <br />
+                  <br />
+                  Key benefits:
+                  <br />&bull; Pay gas in non-TON fee tokens
+                  <br />&bull; ERC-4337 standard EntryPoint and Paymaster
+                  <br />&bull; EntryPoint kept funded through automatic refills
+                  <br />&bull; Available across every preset out of the box
+                </Text>
+              </Flex>
+              <Flex flexDir={"column"} gap={"6px"}>
+                <Text
+                  fontSize={"18px"}
+                  fontWeight={700}
+                  letterSpacing={"-0.54px"}
+                >
+                  How It Works
+                </Text>
+                <Text fontSize={"15px"} fontWeight={400} lineHeight={"18px"}>
+                  The EntryPoint and Multi-Token Paymaster contracts are
+                  predeployed with your chain. When your rollup uses a non-TON
+                  fee token, Account Abstraction activates: TON is pre-deposited
+                  to fund the EntryPoint on the chain&apos;s behalf, and an
+                  auto-refill keeps that balance topped up so user operations
+                  keep flowing. The chain&apos;s admin account maintains a
+                  minimum TON balance to cover these deposits.
+                </Text>
+              </Flex>
+              <Flex flexDir={"column"} gap={"6px"}>
+                <Text
+                  fontSize={"18px"}
+                  fontWeight={700}
+                  letterSpacing={"-0.54px"}
+                >
+                  How to Enable
+                </Text>
+                <Text fontSize={"15px"} fontWeight={400} lineHeight={"18px"}>
+                  Account Abstraction is included in every preset automatically
+                  &mdash; there is nothing to install. Choosing a non-TON fee
+                  token when you deploy activates the paymaster flow. Learn more
+                  about the underlying standard in the{" "}
+                  <Link
+                    _hover={{ textDecoration: "underline" }}
+                    color={"#0070ED"}
+                    href={ERC_4337_SPEC_URL}
+                    target="_blank"
+                  >
+                    ERC-4337 specification
+                  </Link>
+                  .
+                </Text>
+              </Flex>
+            </Flex>
+          </Flex>
+          <Flex
+            p={"24px"}
+            flexDir={"column"}
+            gap={"21px"}
+            borderRadius={"15px"}
+            border={"1px solid #E1E8ED"}
+            bgColor={"#FFF"}
+            w={{ base: "100%", lg: "25%" }}
+          >
+            <Flex flexDir={"column"} gap={"9px"}>
+              <Text fontSize={"15px"} fontWeight={700} letterSpacing={"-0.45px"}>
+                Highlights
+              </Text>
+              <List.Root ml={"15px"}>
+                <List.Item fontSize={"14px"} fontWeight={700} lineHeight={"17px"}>
+                  Pay Gas in Any Token
+                  <Text
+                    as={"span"}
+                    fontSize={"13px"}
+                    fontWeight={400}
+                    lineHeight={"17px"}
+                  >
+                    {" "}
+                    &bull; Users are not limited to native TON
+                  </Text>
+                </List.Item>
+                <List.Item fontSize={"14px"} fontWeight={700} lineHeight={"17px"}>
+                  ERC-4337 Standard
+                  <Text
+                    as={"span"}
+                    fontSize={"13px"}
+                    fontWeight={400}
+                    lineHeight={"17px"}
+                  >
+                    {" "}
+                    &bull; EntryPoint and Paymaster predeploys
+                  </Text>
+                </List.Item>
+                <List.Item fontSize={"14px"} fontWeight={700} lineHeight={"17px"}>
+                  Auto-Refilled
+                  <Text
+                    as={"span"}
+                    fontSize={"13px"}
+                    fontWeight={400}
+                    lineHeight={"17px"}
+                  >
+                    {" "}
+                    &bull; EntryPoint stays funded automatically
+                  </Text>
+                </List.Item>
+              </List.Root>
+            </Flex>
+            <Box height={"1px"} alignSelf={"stretch"} bgColor={"#E1E8ED"} />
+            <Flex flexDir={"column"} gap={"9px"}>
+              <Text fontSize={"15px"} fontWeight={700} letterSpacing={"-0.45px"}>
+                Availability
+              </Text>
+              <Text fontSize={"14px"} fontWeight={400} lineHeight={"17px"}>
+                Built into every rollup, across all presets.
+              </Text>
+            </Flex>
+            <Box height={"1px"} alignSelf={"stretch"} bgColor={"#E1E8ED"} />
+            <Flex flexDir={"column"} gap={"9px"}>
+              <Text fontSize={"15px"} fontWeight={700} letterSpacing={"-0.45px"}>
+                Requirements
+              </Text>
+              <List.Root ml={"15px"}>
+                <List.Item fontSize={"13px"} fontWeight={400} lineHeight={"17px"}>
+                  Deployed Thanos Stack (any preset)
+                </List.Item>
+                <List.Item fontSize={"13px"} fontWeight={400} lineHeight={"17px"}>
+                  Non-TON fee token to activate the paymaster
+                </List.Item>
+              </List.Root>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/src/app/discover/cross-trade/page.tsx
+++ b/src/app/discover/cross-trade/page.tsx
@@ -1,0 +1,319 @@
+"use client";
+import { Box, Flex, Link, List, Text } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import backIcon from "@/assets/icon/back.svg";
+import Image from "next/image";
+import { SocialButton } from "@/components/ui/social-button";
+import { IntegrationLogo } from "@/components/ui/integration-logo";
+import { useState } from "react";
+
+const CROSS_TRADE_RESEARCH_URL =
+  "https://ethresear.ch/t/canonical-cross-chain-swap-fast-and-decentralized-settlement-for-cross-chain-swap-using-canonical-native-l1-l2-messaging/21638/3";
+
+const BackButton = () => {
+  const router = useRouter();
+  const [isHover, setIsHover] = useState(false);
+  return (
+    <Flex
+      gap={"12px"}
+      ml={"30px"}
+      alignItems={"center"}
+      cursor={"pointer"}
+      onClick={() => router.push("/discover?category=integration")}
+      zIndex={100}
+      onMouseEnter={() => setIsHover(true)}
+      onMouseLeave={() => setIsHover(false)}
+    >
+      <Image src={backIcon} alt="back" />
+      <Text
+        fontSize={"18px"}
+        fontWeight={700}
+        letterSpacing={"-0.54px"}
+        cursor={"pointer"}
+        textDecoration={isHover ? "underline" : "none"}
+      >
+        Back
+      </Text>
+    </Flex>
+  );
+};
+
+const RouteComponent = () => {
+  const router = useRouter();
+  return (
+    <Flex
+      gap={"12px"}
+      alignItems={"center"}
+      fontSize={"12px"}
+      lineHeight={"normal"}
+      cursor={"pointer"}
+    >
+      <Text
+        _hover={{ textDecoration: "underline" }}
+        onClick={() => router.push("/discover")}
+      >
+        Discover
+      </Text>
+      <Text opacity={0.25}>/</Text>
+      <Text
+        _hover={{ textDecoration: "underline" }}
+        onClick={() => router.push("/discover?category=integration")}
+      >
+        Integrations
+      </Text>
+      <Text opacity={0.25}>/</Text>
+      <Text color={"#0070ED"}>Cross Trade</Text>
+    </Flex>
+  );
+};
+
+export default function CrossTradePage() {
+  return (
+    <Box
+      pt={{ base: "108px", md: "138px", lg: "198px" }}
+      px={{ base: "15px", md: "31px", lg: "40px" }}
+      pb={"30px"}
+      w={"100%"}
+      minH={`calc(100vh - ${95}px)`}
+      bgColor={"#FAFBFC"}
+    >
+      <Flex flexDir={"column"} gap={"30px"} maxWidth={"1200px"} mx={"auto"}>
+        <Flex
+          position={"absolute"}
+          top={0}
+          left={0}
+          w={"100%"}
+          h={"100vh"}
+          zIndex={1}
+          bg={"url(/images/discover-bg.png) no-repeat center center"}
+          bgSize={"cover"}
+        ></Flex>
+        <BackButton />
+        <Flex
+          gap={"30px"}
+          flexDir={{ base: "column", lg: "row" }}
+          alignItems={"flex-start"}
+          zIndex={100}
+        >
+          <Flex
+            flexDir={"column"}
+            width={{ base: "100%", lg: "75%" }}
+            borderRadius={"15px"}
+            border={"1px solid #E1E8ED"}
+            bgColor={"#FFF"}
+            padding={{ base: "21px 21px 30px 21px", lg: "45px 30px 60px 30px" }}
+            gap={{ base: "60px", lg: "75px" }}
+            alignItems={"flex-start"}
+          >
+            <Flex flexDir={"column"} gap={"45px"}>
+              <RouteComponent />
+              <Flex flexDir={"column"} gap={"18px"}>
+                <Flex alignItems={"center"} gap={"15px"}>
+                  <IntegrationLogo
+                    name={"cross-trade"}
+                    width={60}
+                    height={60}
+                  />
+                  <Flex
+                    gap={{ base: "6px", md: "12px" }}
+                    alignItems={{ base: "flex-start", md: "center" }}
+                    flexDir={{ base: "column", md: "row" }}
+                  >
+                    <Text
+                      fontSize={{ base: "21px", md: "36px" }}
+                      fontWeight={700}
+                      letterSpacing={"-1.08px"}
+                    >
+                      Cross Trade
+                    </Text>
+                    <Text
+                      fontSize={{ base: "13px", md: "14px" }}
+                      fontWeight={400}
+                      lineHeight={"normal"}
+                    >
+                      Fast cross-chain settlement
+                    </Text>
+                  </Flex>
+                </Flex>
+                <Flex
+                  ml={{ base: "0px", md: "60px" }}
+                  flexDir={"column"}
+                  gap={"30px"}
+                >
+                  <Flex flexDir={"column"} gap={"30px"}>
+                    <Flex alignItems={"center"} gap={"45px"}>
+                      <Flex flexDir={"column"} gap={"3px"}>
+                        <Text fontSize={"12px"} fontWeight={400}>
+                          Created by
+                        </Text>
+                        <Text fontSize={"13px"} fontWeight={700}>
+                          Tokamak Rollup Hub Team
+                        </Text>
+                      </Flex>
+                      <Flex flexDir={"column"} gap={"3px"}>
+                        <Text fontSize={"12px"} fontWeight={400}>
+                          Available in
+                        </Text>
+                        <Text fontSize={"13px"} fontWeight={700}>
+                          DeFi &amp; Full presets
+                        </Text>
+                      </Flex>
+                    </Flex>
+                    <Flex gap={"12px"} flexWrap={"wrap"}>
+                      <SocialButton
+                        icon={"document"}
+                        label={"Research"}
+                        link={CROSS_TRADE_RESEARCH_URL}
+                      />
+                    </Flex>
+                  </Flex>
+                </Flex>
+              </Flex>
+            </Flex>
+            <Flex flexDir={"column"} gap={"45px"}>
+              <Flex flexDir={"column"} gap={"6px"}>
+                <Text
+                  fontSize={"18px"}
+                  fontWeight={700}
+                  letterSpacing={"-0.54px"}
+                >
+                  Overview
+                </Text>
+                <Text fontSize={"15px"} fontWeight={400} lineHeight={"18px"}>
+                  Cross Trade lets your chain&apos;s users move assets across
+                  chains without waiting out the standard 7-day withdrawal
+                  challenge period. It supports fast, decentralized withdrawals
+                  between L2 and L1 as well as direct L2-to-L2 transfers,
+                  settled through canonical native L1&harr;L2 messaging.
+                  <br />
+                  <br />
+                  Key benefits:
+                  <br />&bull; Skip the 7-day withdrawal wait for supported
+                  assets
+                  <br />&bull; L2&harr;L1 and L2&harr;L2 transfers
+                  <br />&bull; Decentralized settlement &mdash; no trusted
+                  custodian
+                  <br />&bull; Deployed automatically with the DeFi and Full
+                  presets
+                </Text>
+              </Flex>
+              <Flex flexDir={"column"} gap={"6px"}>
+                <Text
+                  fontSize={"18px"}
+                  fontWeight={700}
+                  letterSpacing={"-0.54px"}
+                >
+                  How It Works
+                </Text>
+                <Text fontSize={"15px"} fontWeight={400} lineHeight={"18px"}>
+                  A liquidity provider fronts the requested asset on the
+                  destination chain immediately, then reclaims the locked funds
+                  on the source chain once the canonical cross-chain message is
+                  finalized. Because settlement relies on native L1&harr;L2
+                  messaging rather than a third-party bridge, users receive
+                  funds quickly while the protocol remains trust-minimized.
+                </Text>
+              </Flex>
+              <Flex flexDir={"column"} gap={"6px"}>
+                <Text
+                  fontSize={"18px"}
+                  fontWeight={700}
+                  letterSpacing={"-0.54px"}
+                >
+                  How to Enable
+                </Text>
+                <Text fontSize={"15px"} fontWeight={400} lineHeight={"18px"}>
+                  Cross Trade is included out of the box when you deploy your
+                  Thanos Stack with the DeFi or Full preset &mdash; no manual
+                  setup required. Read the design rationale in the{" "}
+                  <Link
+                    _hover={{ textDecoration: "underline" }}
+                    color={"#0070ED"}
+                    href={CROSS_TRADE_RESEARCH_URL}
+                    target="_blank"
+                  >
+                    canonical cross-chain swap research
+                  </Link>
+                  .
+                </Text>
+              </Flex>
+            </Flex>
+          </Flex>
+          <Flex
+            p={"24px"}
+            flexDir={"column"}
+            gap={"21px"}
+            borderRadius={"15px"}
+            border={"1px solid #E1E8ED"}
+            bgColor={"#FFF"}
+            w={{ base: "100%", lg: "25%" }}
+          >
+            <Flex flexDir={"column"} gap={"9px"}>
+              <Text fontSize={"15px"} fontWeight={700} letterSpacing={"-0.45px"}>
+                Highlights
+              </Text>
+              <List.Root ml={"15px"}>
+                <List.Item fontSize={"14px"} fontWeight={700} lineHeight={"17px"}>
+                  No 7-Day Wait
+                  <Text
+                    as={"span"}
+                    fontSize={"13px"}
+                    fontWeight={400}
+                    lineHeight={"17px"}
+                  >
+                    {" "}
+                    &bull; Fast withdrawals for supported assets
+                  </Text>
+                </List.Item>
+                <List.Item fontSize={"14px"} fontWeight={700} lineHeight={"17px"}>
+                  L2&harr;L1 &amp; L2&harr;L2
+                  <Text
+                    as={"span"}
+                    fontSize={"13px"}
+                    fontWeight={400}
+                    lineHeight={"17px"}
+                  >
+                    {" "}
+                    &bull; Move assets in both directions
+                  </Text>
+                </List.Item>
+                <List.Item fontSize={"14px"} fontWeight={700} lineHeight={"17px"}>
+                  Decentralized
+                  <Text
+                    as={"span"}
+                    fontSize={"13px"}
+                    fontWeight={400}
+                    lineHeight={"17px"}
+                  >
+                    {" "}
+                    &bull; Settlement via canonical messaging
+                  </Text>
+                </List.Item>
+              </List.Root>
+            </Flex>
+            <Box height={"1px"} alignSelf={"stretch"} bgColor={"#E1E8ED"} />
+            <Flex flexDir={"column"} gap={"9px"}>
+              <Text fontSize={"15px"} fontWeight={700} letterSpacing={"-0.45px"}>
+                Availability
+              </Text>
+              <Text fontSize={"14px"} fontWeight={400} lineHeight={"17px"}>
+                Deployed automatically with the DeFi and Full presets.
+              </Text>
+            </Flex>
+            <Box height={"1px"} alignSelf={"stretch"} bgColor={"#E1E8ED"} />
+            <Flex flexDir={"column"} gap={"9px"}>
+              <Text fontSize={"15px"} fontWeight={700} letterSpacing={"-0.45px"}>
+                Requirements
+              </Text>
+              <List.Root ml={"15px"}>
+                <List.Item fontSize={"13px"} fontWeight={400} lineHeight={"17px"}>
+                  Deployed Thanos Stack (DeFi or Full preset)
+                </List.Item>
+              </List.Root>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/src/app/discover/dao-candidate/page.tsx
+++ b/src/app/discover/dao-candidate/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Box, Flex, Link, List, Text } from "@chakra-ui/react";
+import { Box, Flex, Link, Text } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import backIcon from "@/assets/icon/back.svg";
 import Image from "next/image";

--- a/src/app/discover/monitoring-tool/page.tsx
+++ b/src/app/discover/monitoring-tool/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Box, Flex, Link, List, Text } from "@chakra-ui/react";
+import { Box, Flex, List, Text } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import backIcon from "@/assets/icon/back.svg";
 import Image from "next/image";

--- a/src/app/discover/rng/page.tsx
+++ b/src/app/discover/rng/page.tsx
@@ -1,0 +1,332 @@
+"use client";
+import { Box, Flex, Link, List, Text } from "@chakra-ui/react";
+import { useRouter } from "next/navigation";
+import backIcon from "@/assets/icon/back.svg";
+import Image from "next/image";
+import { SocialButton } from "@/components/ui/social-button";
+import { IntegrationLogo } from "@/components/ui/integration-logo";
+import { useState } from "react";
+
+const COMMIT_REVEAL2_URL =
+  "https://github.com/tokamak-network/Commit-Reveal2";
+
+const DRB_NODE_URL = "https://github.com/tokamak-network/DRB-node";
+
+const BackButton = () => {
+  const router = useRouter();
+  const [isHover, setIsHover] = useState(false);
+  return (
+    <Flex
+      gap={"12px"}
+      ml={"30px"}
+      alignItems={"center"}
+      cursor={"pointer"}
+      onClick={() => router.push("/discover?category=integration")}
+      zIndex={100}
+      onMouseEnter={() => setIsHover(true)}
+      onMouseLeave={() => setIsHover(false)}
+    >
+      <Image src={backIcon} alt="back" />
+      <Text
+        fontSize={"18px"}
+        fontWeight={700}
+        letterSpacing={"-0.54px"}
+        cursor={"pointer"}
+        textDecoration={isHover ? "underline" : "none"}
+      >
+        Back
+      </Text>
+    </Flex>
+  );
+};
+
+const RouteComponent = () => {
+  const router = useRouter();
+  return (
+    <Flex
+      gap={"12px"}
+      alignItems={"center"}
+      fontSize={"12px"}
+      lineHeight={"normal"}
+      cursor={"pointer"}
+    >
+      <Text
+        _hover={{ textDecoration: "underline" }}
+        onClick={() => router.push("/discover")}
+      >
+        Discover
+      </Text>
+      <Text opacity={0.25}>/</Text>
+      <Text
+        _hover={{ textDecoration: "underline" }}
+        onClick={() => router.push("/discover?category=integration")}
+      >
+        Integrations
+      </Text>
+      <Text opacity={0.25}>/</Text>
+      <Text color={"#0070ED"}>Random Number Generation</Text>
+    </Flex>
+  );
+};
+
+export default function RngPage() {
+  return (
+    <Box
+      pt={{ base: "108px", md: "138px", lg: "198px" }}
+      px={{ base: "15px", md: "31px", lg: "40px" }}
+      pb={"30px"}
+      w={"100%"}
+      minH={`calc(100vh - ${95}px)`}
+      bgColor={"#FAFBFC"}
+    >
+      <Flex flexDir={"column"} gap={"30px"} maxWidth={"1200px"} mx={"auto"}>
+        <Flex
+          position={"absolute"}
+          top={0}
+          left={0}
+          w={"100%"}
+          h={"100vh"}
+          zIndex={1}
+          bg={"url(/images/discover-bg.png) no-repeat center center"}
+          bgSize={"cover"}
+        ></Flex>
+        <BackButton />
+        <Flex
+          gap={"30px"}
+          flexDir={{ base: "column", lg: "row" }}
+          alignItems={"flex-start"}
+          zIndex={100}
+        >
+          <Flex
+            flexDir={"column"}
+            width={{ base: "100%", lg: "75%" }}
+            borderRadius={"15px"}
+            border={"1px solid #E1E8ED"}
+            bgColor={"#FFF"}
+            padding={{ base: "21px 21px 30px 21px", lg: "45px 30px 60px 30px" }}
+            gap={{ base: "60px", lg: "75px" }}
+            alignItems={"flex-start"}
+          >
+            <Flex flexDir={"column"} gap={"45px"}>
+              <RouteComponent />
+              <Flex flexDir={"column"} gap={"18px"}>
+                <Flex alignItems={"center"} gap={"15px"}>
+                  <IntegrationLogo name={"rng"} width={60} height={60} />
+                  <Flex
+                    gap={{ base: "6px", md: "12px" }}
+                    alignItems={{ base: "flex-start", md: "center" }}
+                    flexDir={{ base: "column", md: "row" }}
+                  >
+                    <Text
+                      fontSize={{ base: "21px", md: "36px" }}
+                      fontWeight={700}
+                      letterSpacing={"-1.08px"}
+                    >
+                      Random Number Generation
+                    </Text>
+                    <Text
+                      fontSize={{ base: "13px", md: "14px" }}
+                      fontWeight={400}
+                      lineHeight={"normal"}
+                    >
+                      Powered by Tokamak DRB
+                    </Text>
+                  </Flex>
+                </Flex>
+                <Flex
+                  ml={{ base: "0px", md: "60px" }}
+                  flexDir={"column"}
+                  gap={"30px"}
+                >
+                  <Flex flexDir={"column"} gap={"30px"}>
+                    <Flex alignItems={"center"} gap={"45px"}>
+                      <Flex flexDir={"column"} gap={"3px"}>
+                        <Text fontSize={"12px"} fontWeight={400}>
+                          Created by
+                        </Text>
+                        <Text fontSize={"13px"} fontWeight={700}>
+                          Tokamak Rollup Hub Team
+                        </Text>
+                      </Flex>
+                      <Flex flexDir={"column"} gap={"3px"}>
+                        <Text fontSize={"12px"} fontWeight={400}>
+                          Available in
+                        </Text>
+                        <Text fontSize={"13px"} fontWeight={700}>
+                          Gaming &amp; Full presets
+                        </Text>
+                      </Flex>
+                    </Flex>
+                    <Flex gap={"12px"} flexWrap={"wrap"}>
+                      <SocialButton
+                        icon={"github"}
+                        label={"Commit-Reveal2"}
+                        link={COMMIT_REVEAL2_URL}
+                      />
+                      <SocialButton
+                        icon={"github"}
+                        label={"DRB Node"}
+                        link={DRB_NODE_URL}
+                      />
+                    </Flex>
+                  </Flex>
+                </Flex>
+              </Flex>
+            </Flex>
+            <Flex flexDir={"column"} gap={"45px"}>
+              <Flex flexDir={"column"} gap={"6px"}>
+                <Text
+                  fontSize={"18px"}
+                  fontWeight={700}
+                  letterSpacing={"-0.54px"}
+                >
+                  Overview
+                </Text>
+                <Text fontSize={"15px"} fontWeight={400} lineHeight={"18px"}>
+                  Random Number Generation brings manipulation-resistant
+                  on-chain randomness to your chain through the Tokamak
+                  Distributed Random Beacon (DRB). It gives smart contracts a
+                  verifiable source of randomness &mdash; ideal for gaming,
+                  lotteries, fair ordering, and other use cases that need
+                  tamper-proof entropy.
+                  <br />
+                  <br />
+                  Key benefits:
+                  <br />&bull; Manipulation-resistant randomness no single party
+                  can bias
+                  <br />&bull; Verifiable on-chain output
+                  <br />&bull; Distributed operator set, no trusted third party
+                  <br />&bull; Deployed automatically with the Gaming and Full
+                  presets
+                </Text>
+              </Flex>
+              <Flex flexDir={"column"} gap={"6px"}>
+                <Text
+                  fontSize={"18px"}
+                  fontWeight={700}
+                  letterSpacing={"-0.54px"}
+                >
+                  How It Works
+                </Text>
+                <Text fontSize={"15px"} fontWeight={400} lineHeight={"18px"}>
+                  DRB uses a two-phase commit-reveal protocol. In the commit
+                  phase, participants lock in hidden values that produce an
+                  intermediate value. In the reveal phase, the reveal order is
+                  itself randomized from those commitments, so no participant
+                  can predict or claim the final position. This defeats the
+                  &ldquo;last revealer&rdquo; attack that lets an actor peek at
+                  the outcome and strategically withhold their reveal.
+                </Text>
+              </Flex>
+              <Flex flexDir={"column"} gap={"6px"}>
+                <Text
+                  fontSize={"18px"}
+                  fontWeight={700}
+                  letterSpacing={"-0.54px"}
+                >
+                  How to Enable
+                </Text>
+                <Text fontSize={"15px"} fontWeight={400} lineHeight={"18px"}>
+                  DRB is provisioned automatically when you deploy your Thanos
+                  Stack with the Gaming or Full preset &mdash; no manual setup
+                  required. Explore the protocol contracts in{" "}
+                  <Link
+                    _hover={{ textDecoration: "underline" }}
+                    color={"#0070ED"}
+                    href={COMMIT_REVEAL2_URL}
+                    target="_blank"
+                  >
+                    Commit-Reveal2
+                  </Link>{" "}
+                  and the node software in{" "}
+                  <Link
+                    _hover={{ textDecoration: "underline" }}
+                    color={"#0070ED"}
+                    href={DRB_NODE_URL}
+                    target="_blank"
+                  >
+                    DRB-node
+                  </Link>
+                  .
+                </Text>
+              </Flex>
+            </Flex>
+          </Flex>
+          <Flex
+            p={"24px"}
+            flexDir={"column"}
+            gap={"21px"}
+            borderRadius={"15px"}
+            border={"1px solid #E1E8ED"}
+            bgColor={"#FFF"}
+            w={{ base: "100%", lg: "25%" }}
+          >
+            <Flex flexDir={"column"} gap={"9px"}>
+              <Text fontSize={"15px"} fontWeight={700} letterSpacing={"-0.45px"}>
+                Highlights
+              </Text>
+              <List.Root ml={"15px"}>
+                <List.Item fontSize={"14px"} fontWeight={700} lineHeight={"17px"}>
+                  Manipulation-Resistant
+                  <Text
+                    as={"span"}
+                    fontSize={"13px"}
+                    fontWeight={400}
+                    lineHeight={"17px"}
+                  >
+                    {" "}
+                    &bull; Two-phase commit-reveal design
+                  </Text>
+                </List.Item>
+                <List.Item fontSize={"14px"} fontWeight={700} lineHeight={"17px"}>
+                  On-Chain Verifiable
+                  <Text
+                    as={"span"}
+                    fontSize={"13px"}
+                    fontWeight={400}
+                    lineHeight={"17px"}
+                  >
+                    {" "}
+                    &bull; Randomness contracts can verify
+                  </Text>
+                </List.Item>
+                <List.Item fontSize={"14px"} fontWeight={700} lineHeight={"17px"}>
+                  Built for Gaming
+                  <Text
+                    as={"span"}
+                    fontSize={"13px"}
+                    fontWeight={400}
+                    lineHeight={"17px"}
+                  >
+                    {" "}
+                    &bull; Fair entropy for on-chain games
+                  </Text>
+                </List.Item>
+              </List.Root>
+            </Flex>
+            <Box height={"1px"} alignSelf={"stretch"} bgColor={"#E1E8ED"} />
+            <Flex flexDir={"column"} gap={"9px"}>
+              <Text fontSize={"15px"} fontWeight={700} letterSpacing={"-0.45px"}>
+                Availability
+              </Text>
+              <Text fontSize={"14px"} fontWeight={400} lineHeight={"17px"}>
+                Deployed automatically with the Gaming and Full presets.
+              </Text>
+            </Flex>
+            <Box height={"1px"} alignSelf={"stretch"} bgColor={"#E1E8ED"} />
+            <Flex flexDir={"column"} gap={"9px"}>
+              <Text fontSize={"15px"} fontWeight={700} letterSpacing={"-0.45px"}>
+                Requirements
+              </Text>
+              <List.Root ml={"15px"}>
+                <List.Item fontSize={"13px"} fontWeight={400} lineHeight={"17px"}>
+                  Deployed Thanos Stack (Gaming or Full preset)
+                </List.Item>
+              </List.Root>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/src/app/discover/thanos-stack/page.tsx
+++ b/src/app/discover/thanos-stack/page.tsx
@@ -6,7 +6,6 @@ import Image from "next/image";
 import { SocialButton } from "@/components/ui/social-button";
 import { IntegrationLogo } from "@/components/ui/integration-logo";
 import { useState } from "react";
-import { THANOS_STACK_DEPLOYMENT_GUIDE_URL } from "@/consts/urls";
 const BackButton = () => {
   const router = useRouter();
   const [isHover, setIsHover] = useState(false);

--- a/src/components/landing-page/AnnouncementBanner.tsx
+++ b/src/components/landing-page/AnnouncementBanner.tsx
@@ -1,8 +1,7 @@
 "use client";
-import { Flex, Box, Text, VStack, HStack, Link } from "@chakra-ui/react";
+import { Flex, Box, Text, Link } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
 import Image from "next/image";
-import CloseIcon from "@/assets/icon/close.svg";
 import Logo from "@/assets/logo/logo.svg";
 import { PLATFORM_GUIDE_URL } from "@/consts/urls";
 import "./banner.css";
@@ -17,13 +16,6 @@ export default function AnnouncementBanner() {
       setIsVisible(true);
     }
   }, []);
-
-  const handleClose = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setIsVisible(false);
-    localStorage.setItem("banner-dismissed", "true");
-    window.dispatchEvent(new Event("banner-dismissed"));
-  };
 
   const handleBannerClick = () => {
     setIsModalOpen(true);

--- a/src/components/landing-page/ComponentCarouselComponent.tsx
+++ b/src/components/landing-page/ComponentCarouselComponent.tsx
@@ -5,7 +5,6 @@ import Carousel from "react-multi-carousel";
 import CardComponent from "./CardComponent";
 import "react-multi-carousel/lib/styles.css";
 import { useRef, useEffect } from "react";
-import Link from "next/link";
 
 const responsive = {
   superLargeDesktop: {
@@ -60,7 +59,7 @@ const BlockExplorerComponent = () => {
       description={
         <>
           Easily deploy an explorer for your chain with our SDK and make it
-          accessible to your network's users.
+          accessible to your network&apos;s users.
         </>
       }
       featured={true}
@@ -73,27 +72,18 @@ const BlockExplorerComponent = () => {
 const CrossTradeComponent = () => {
   return (
     <CardComponent
-      title={"Cross Trade (Coming Soon)"}
+      title={"Cross Trade"}
       description={
         <>
           <Text as={"span"} fontWeight={700}>
             Cross Trade
           </Text>{" "}
           enables fast, decentralized withdrawals between L2 and L1 chains, as
-          well as L2-L2 transfers. Learn more{" "}
-          <Link
-            href={
-              "https://ethresear.ch/t/canonical-cross-chain-swap-fast-and-decentralized-settlement-for-cross-chain-swap-using-canonical-native-l1-l2-messaging/21638/3"
-            }
-            target="_blank"
-          >
-            <Text as={"span"} fontWeight={500} textDecoration={"underline"}>
-              here
-            </Text>
-          </Link>
+          well as L2-L2 transfers. Included in the DeFi and Full presets.
         </>
       }
-      featured={false}
+      featured={true}
+      link={"/discover/cross-trade"}
       iconId={"cross-trade"}
     />
   );
@@ -123,25 +113,19 @@ const StakingDAOComponent = () => {
 const RandomNumberGenerationComponent = () => {
   return (
     <CardComponent
-      title={"Random Number Generation (Coming Soon)"}
+      title={"Random Number Generation"}
       description={
         <>
           <Text as={"span"} fontWeight={700}>
             Random Number Generation
           </Text>{" "}
-          Integrate random number generation into your chain with our RNG
-          project. Learn more{" "}
-          <Link
-            href={"https://github.com/tokamak-network/Randomness-Beacon"}
-            target="_blank"
-          >
-            <Text as={"span"} fontWeight={500} textDecoration={"underline"}>
-              here
-            </Text>
-          </Link>
+          brings manipulation-resistant on-chain randomness to your chain via
+          the Tokamak Distributed Random Beacon (DRB). Included in the Gaming
+          and Full presets.
         </>
       }
-      featured={false}
+      featured={true}
+      link={"/discover/rng"}
       iconId={"rng"}
     />
   );
@@ -178,6 +162,27 @@ const UptimeKumaComponent = () => {
       featured={true}
       link={"/discover/uptime-kuma"}
       iconId={"uptime-kuma"}
+    />
+  );
+};
+
+const AccountAbstractionComponent = () => {
+  return (
+    <CardComponent
+      title={"Account Abstraction"}
+      description={
+        <>
+          <Text as={"span"} fontWeight={700}>
+            Account Abstraction
+          </Text>{" "}
+          (ERC-4337) with a Multi-Token Paymaster lets your users pay gas in
+          tokens other than the native TON. Built into every rollup across all
+          presets.
+        </>
+      }
+      featured={true}
+      link={"/discover/account-abstraction"}
+      iconId={"account-abstraction"}
     />
   );
 };
@@ -268,6 +273,7 @@ export default function ComponentCarouselComponent() {
         <MonitoringToolComponent />
         <UptimeKumaComponent />
         <StakingDAOComponent />
+        <AccountAbstractionComponent />
         <CrossTradeComponent />
         <RandomNumberGenerationComponent />
       </Carousel>

--- a/src/components/landing-page/PresetSection.tsx
+++ b/src/components/landing-page/PresetSection.tsx
@@ -1,0 +1,136 @@
+import { Box, Flex, Link, Text } from "@chakra-ui/react";
+import { IntegrationLogo } from "@/components/ui/integration-logo";
+import { PRESET_LIST, PRESET_SECTION } from "@/consts/presets";
+import { PLATFORM_GUIDE_URL } from "@/consts/urls";
+
+export default function PresetSection() {
+  return (
+    <Flex flexDir={"column"} gap={"45px"} justifyContent={"center"}>
+      <Flex flexDir={"column"} gap={"15px"}>
+        <Text
+          width={"100%"}
+          fontSize={{ base: "42px", md: "54px" }}
+          fontWeight={700}
+          lineHeight={"normal"}
+          letterSpacing={"-1.62px"}
+        >
+          {PRESET_SECTION.title}
+        </Text>
+        <Text
+          color={"#252525"}
+          fontSize={"16px"}
+          fontWeight={400}
+          lineHeight={"22px"}
+          maxW={"760px"}
+        >
+          {PRESET_SECTION.description}
+        </Text>
+      </Flex>
+
+      <Flex
+        gap={"24px"}
+        alignItems={"stretch"}
+        flexDir={{ base: "column", lg: "row" }}
+      >
+        {PRESET_LIST.map((preset) => (
+          <Flex
+            key={preset.id}
+            flex={1}
+            flexDir={"column"}
+            gap={"18px"}
+            p={"24px"}
+            border={"1px solid #C8D3DC"}
+            borderRadius={"15px"}
+            bgColor={"#FFF"}
+          >
+            <Flex alignItems={"center"} justifyContent={"space-between"} gap={"12px"}>
+              <Text
+                fontSize={"24px"}
+                fontWeight={700}
+                lineHeight={"normal"}
+                letterSpacing={"-0.72px"}
+                color={preset.accent}
+              >
+                {preset.name}
+              </Text>
+              <Text
+                as={"span"}
+                fontSize={"12px"}
+                fontWeight={600}
+                color={preset.accent}
+                bgColor={`${preset.accent}14`}
+                px={"10px"}
+                py={"4px"}
+                borderRadius={"999px"}
+                whiteSpace={"nowrap"}
+              >
+                {preset.deployTime}
+              </Text>
+            </Flex>
+
+            <Text
+              fontSize={"14px"}
+              fontWeight={500}
+              lineHeight={"20px"}
+              color={"#252525"}
+              minH={{ base: "auto", lg: "40px" }}
+            >
+              {preset.tagline}
+            </Text>
+
+            <Box w={"100%"} h={"1px"} bgColor={"#E1E8ED"} />
+
+            <Flex flexDir={"column"} gap={"10px"}>
+              <Text
+                fontSize={"12px"}
+                fontWeight={600}
+                letterSpacing={"0.5px"}
+                textTransform={"uppercase"}
+                color={"#9CA3AF"}
+              >
+                Includes
+              </Text>
+              <Flex gap={"8px"} flexWrap={"wrap"}>
+                {preset.moduleIcons.map((icon) => (
+                  <Flex
+                    key={icon}
+                    alignItems={"center"}
+                    justifyContent={"center"}
+                    w={"36px"}
+                    h={"36px"}
+                    borderRadius={"9px"}
+                    border={"1px solid #E1E8ED"}
+                    bgColor={"#FAFBFC"}
+                  >
+                    <IntegrationLogo name={icon} width={22} height={22} />
+                  </Flex>
+                ))}
+              </Flex>
+              <Text
+                fontSize={"12px"}
+                fontWeight={400}
+                lineHeight={"17px"}
+                color={"#6B7280"}
+              >
+                {preset.extras}
+              </Text>
+            </Flex>
+          </Flex>
+        ))}
+      </Flex>
+
+      <Link
+        href={PLATFORM_GUIDE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        alignSelf={"flex-start"}
+        fontSize={"16px"}
+        fontWeight={600}
+        color={"#0070ED"}
+        _hover={{ textDecoration: "underline" }}
+      >
+        Deploy with a preset →
+      </Link>
+    </Flex>
+  );
+}

--- a/src/components/landing-page/PresetSection.tsx
+++ b/src/components/landing-page/PresetSection.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Link, Text } from "@chakra-ui/react";
 import { IntegrationLogo } from "@/components/ui/integration-logo";
-import { PRESET_LIST, PRESET_SECTION } from "@/consts/presets";
+import { Tooltip } from "@/components/ui/tooltip";
+import { MODULE_LABELS, PRESET_LIST, PRESET_SECTION } from "@/consts/presets";
 import { PLATFORM_GUIDE_URL } from "@/consts/urls";
 
 export default function PresetSection() {
@@ -91,20 +92,25 @@ export default function PresetSection() {
                 Includes
               </Text>
               <Flex gap={"8px"} flexWrap={"wrap"}>
-                {preset.moduleIcons.map((icon) => (
-                  <Flex
-                    key={icon}
-                    alignItems={"center"}
-                    justifyContent={"center"}
-                    w={"36px"}
-                    h={"36px"}
-                    borderRadius={"9px"}
-                    border={"1px solid #E1E8ED"}
-                    bgColor={"#FAFBFC"}
-                  >
-                    <IntegrationLogo name={icon} width={22} height={22} />
-                  </Flex>
-                ))}
+                {preset.moduleIcons.map((icon) => {
+                  const label = MODULE_LABELS[icon] ?? icon;
+                  return (
+                    <Tooltip key={icon} content={label} showArrow openDelay={100}>
+                      <Flex
+                        aria-label={label}
+                        alignItems={"center"}
+                        justifyContent={"center"}
+                        w={"36px"}
+                        h={"36px"}
+                        borderRadius={"9px"}
+                        border={"1px solid #E1E8ED"}
+                        bgColor={"#FAFBFC"}
+                      >
+                        <IntegrationLogo name={icon} width={22} height={22} />
+                      </Flex>
+                    </Tooltip>
+                  );
+                })}
               </Flex>
               <Text
                 fontSize={"12px"}

--- a/src/components/landing-page/PresetSection.tsx
+++ b/src/components/landing-page/PresetSection.tsx
@@ -95,7 +95,23 @@ export default function PresetSection() {
                 {preset.moduleIcons.map((icon) => {
                   const label = MODULE_LABELS[icon] ?? icon;
                   return (
-                    <Tooltip key={icon} content={label} showArrow openDelay={100}>
+                    <Tooltip
+                      key={icon}
+                      content={label}
+                      openDelay={100}
+                      positioning={{ placement: "top", gutter: 8 }}
+                      contentProps={{
+                        bg: "#1C1C1C",
+                        color: "white",
+                        px: "10px",
+                        py: "6px",
+                        borderRadius: "6px",
+                        fontSize: "12px",
+                        fontWeight: 600,
+                        boxShadow: "0 4px 12px rgba(0,0,0,0.18)",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
                       <Flex
                         aria-label={label}
                         alignItems={"center"}

--- a/src/components/ui/integration-logo.tsx
+++ b/src/components/ui/integration-logo.tsx
@@ -17,6 +17,7 @@ const INTEGRATION_LOGO_MAP = {
   "uptime-kuma": "/icon/systempulse.svg",
   "cross-trade": "/icon/corsstrade.png",
   "rng": "/icon/rng.png",
+  "account-abstraction": "/icon/account-abstraction.svg",
 };
 
 export const IntegrationLogo: React.FC<IntegrationLogoProps> = ({

--- a/src/consts/components.ts
+++ b/src/consts/components.ts
@@ -21,7 +21,15 @@ export const PRODUCT_CATEGORIES: ProductDetailType[] = [
 export const SUB_CATEGORY_MAP: Record<string, string[]> = {
   all: [],
   stack: [],
-  integration: ["Block Explorer", "Bridge", "Monitoring", "Staking"],
+  integration: [
+    "Block Explorer",
+    "Bridge",
+    "Monitoring",
+    "Staking",
+    "Interoperability",
+    "Randomness",
+    "Account Abstraction",
+  ],
 };
 
 export const SUB_PRODUCT_CATEGORIES: Record<string, SubProductDetailType[]> = {
@@ -91,6 +99,33 @@ export const SUB_PRODUCT_CATEGORIES: Record<string, SubProductDetailType[]> = {
       link: "/discover/uptime-kuma",
       category: "integration",
       subCategory: "Monitoring",
+    },
+    {
+      id: "cross-trade",
+      name: "Cross Trade",
+      description:
+        "Cross Trade enables fast, decentralized withdrawals between L2 and L1 chains, as well as L2-L2 transfers. Included in the DeFi and Full presets.",
+      link: "/discover/cross-trade",
+      category: "integration",
+      subCategory: "Interoperability",
+    },
+    {
+      id: "rng",
+      name: "Random Number Generation",
+      description:
+        "Manipulation-resistant on-chain randomness via the Tokamak Distributed Random Beacon (DRB). Included in the Gaming and Full presets.",
+      link: "/discover/rng",
+      category: "integration",
+      subCategory: "Randomness",
+    },
+    {
+      id: "account-abstraction",
+      name: "Account Abstraction",
+      description:
+        "ERC-4337 Account Abstraction with a Multi-Token Paymaster lets users pay gas in tokens other than the native TON. Built into every rollup across all presets.",
+      link: "/discover/account-abstraction",
+      category: "integration",
+      subCategory: "Account Abstraction",
     },
     // {
     //   id: "earn-ton-as-reward",

--- a/src/consts/presets.ts
+++ b/src/consts/presets.ts
@@ -4,6 +4,17 @@ export const PRESET_SECTION = {
     "Pick one preset and your rollup's genesis config, predeploy contracts, and modules are all set for you — deployment inputs drop from dozens to a handful.",
 };
 
+// Display names for the module icon chips (keyed by IntegrationLogo name)
+export const MODULE_LABELS: Record<string, string> = {
+  "thanos-bridge": "Thanos Bridge",
+  "thanos-explorer": "Thanos Explorer",
+  "monitoring-tool": "Monitoring Tool",
+  "uptime-kuma": "System Pulse",
+  "cross-trade": "Cross Trade",
+  rng: "Random Number Generation",
+  "account-abstraction": "Account Abstraction",
+};
+
 export interface PresetDetail {
   id: string;
   name: string;

--- a/src/consts/presets.ts
+++ b/src/consts/presets.ts
@@ -1,0 +1,77 @@
+export const PRESET_SECTION = {
+  title: "Start with a Preset",
+  description:
+    "Pick one preset and your rollup's genesis config, predeploy contracts, and modules are all set for you — deployment inputs drop from dozens to a handful.",
+};
+
+export interface PresetDetail {
+  id: string;
+  name: string;
+  tagline: string;
+  deployTime: string;
+  extras: string;
+  // IntegrationLogo names — bundled integrations shown as icon chips
+  moduleIcons: string[];
+  accent: string;
+}
+
+export const PRESET_LIST: PresetDetail[] = [
+  {
+    id: "general",
+    name: "General",
+    tagline: "The essentials to launch your L2.",
+    deployTime: "~12 min",
+    extras: "Native TON L2 · WTON · L2 ETH",
+    moduleIcons: ["thanos-bridge", "thanos-explorer", "account-abstraction"],
+    accent: "#0070ED",
+  },
+  {
+    id: "defi",
+    name: "DeFi",
+    tagline: "Ready for on-chain finance.",
+    deployTime: "~18 min",
+    extras: "Everything in General + Uniswap V3",
+    moduleIcons: [
+      "thanos-bridge",
+      "thanos-explorer",
+      "monitoring-tool",
+      "uptime-kuma",
+      "cross-trade",
+      "account-abstraction",
+    ],
+    accent: "#7C3AED",
+  },
+  {
+    id: "gaming",
+    name: "Gaming",
+    tagline: "Built for on-chain games.",
+    deployTime: "~20 min",
+    extras: "Everything in General + DRB VRF randomness",
+    moduleIcons: [
+      "thanos-bridge",
+      "thanos-explorer",
+      "monitoring-tool",
+      "uptime-kuma",
+      "rng",
+      "account-abstraction",
+    ],
+    accent: "#059669",
+  },
+  {
+    id: "full",
+    name: "Full",
+    tagline: "Everything, out of the box.",
+    deployTime: "~25 min",
+    extras: "Every integration + Backup & Recovery",
+    moduleIcons: [
+      "thanos-bridge",
+      "thanos-explorer",
+      "monitoring-tool",
+      "uptime-kuma",
+      "cross-trade",
+      "rng",
+      "account-abstraction",
+    ],
+    accent: "#DC2626",
+  },
+];

--- a/src/containers/landing-page/DetailContainer.tsx
+++ b/src/containers/landing-page/DetailContainer.tsx
@@ -2,6 +2,7 @@ import BlockComponent from "@/components/landing-page/BlockComponet";
 import ComponentCarouselComponent from "@/components/landing-page/ComponentCarouselComponent";
 import EndingComponent from "@/components/landing-page/EndingComponent";
 import KeyOfferingComponent from "@/components/landing-page/KeyOfferingComponent";
+import PresetSection from "@/components/landing-page/PresetSection";
 import { Flex } from "@chakra-ui/react";
 
 export default function DetailContainer() {
@@ -20,6 +21,7 @@ export default function DetailContainer() {
       >
         <BlockComponent />
         <KeyOfferingComponent />
+        <PresetSection />
         <ComponentCarouselComponent />
         <EndingComponent />
       </Flex>


### PR DESCRIPTION
## Summary

Sync the landing page with the shipped product after auditing `trh-platform`, `trh-backend`, and `trh-platform-ui` against the current site.

### Changes
- **Cross Trade & Random Number Generation** — were marked "Coming Soon" but are live (DeFi/Full and Gaming/Full presets). Promoted to featured cards with new `/discover/cross-trade` and `/discover/rng` detail pages. Fixed the RNG "learn more" link to point at the real repos (Commit-Reveal2 / DRB-node).
- **Account Abstraction** — added a new card + `/discover/account-abstraction` detail page + icon. ERC-4337 Multi-Token Paymaster is built into every preset (lets users pay gas in non-TON tokens) and was previously missing from the site.
- **"Start with a Preset" section** — new home section introducing the four presets (General / DeFi / Gaming / Full) with taglines, approximate deploy times, and integration icon chips, framing the quick-start story (one preset choice configures the whole rollup).
- **Lint cleanup** — removed pre-existing unused imports/vars and escaped an entity so `next build` lint stage passes cleanly.

### Investigated — no change needed
- **Staking / DAO Candidate Registration** — the landing is accurate; it is a working, manually-installable integration. The product's "Coming Soon" badge applies only to the deploy-time preset-config toggle, which the landing never claims.
- **"Thanos" branding** — the landing uses "Thanos Bridge/Explorer/Stack" while the in-app UI uses plain "Bridge/Explorer". "Thanos" is the real stack name (`tokamak-thanos`), so this is a branding-style choice, not an error — left for the marketing/product team to decide.
- **Announcement banner** ("Ends Jan 16") — already disabled (commented out in `layout.tsx`); not rendered.

### Verification
- `tsc --noEmit` → clean
- `next lint` → passes (errors: 0)
- `next build` → compiles, all 17 routes generated
- Browser smoke test: new routes render (200), carousel and preset section render correctly, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
